### PR TITLE
support passing context as None

### DIFF
--- a/junkie/context.py
+++ b/junkie/context.py
@@ -5,13 +5,16 @@ from junkie.core_context import CoreContext
 
 
 class Context(CoreContext):
-    def __init__(self, *instances_and_factories_args: Union[Dict[str, object], Dict[str, Callable]]):
+    def __init__(self, *instances_and_factories_args: Union[Dict[str, object], Dict[str, Callable], None]):
         super().__init__()
 
         self.add(*instances_and_factories_args)
 
-    def add(self, *instances_and_factories_args: Union[Dict[str, object], Dict[str, Callable]]):
+    def add(self, *instances_and_factories_args: Union[Dict[str, object], Dict[str, Callable], None]):
         for instances_and_factories in instances_and_factories_args:
+            if instances_and_factories is None:
+                continue
+
             for key, value in instances_and_factories.items():
                 if callable(value):
                     self._factories[key] = value

--- a/test/context_test.py
+++ b/test/context_test.py
@@ -38,6 +38,13 @@ class ContextTest(unittest.TestCase):
         with context.build(Class) as instance:
             self.assertEqual("abcxyz", instance.text)
 
+    def test_add_none_context(self):
+        context = Context({"value": "abc"}, None)
+        context.add(None)
+
+        with context.build("value") as value:
+            self.assertEqual("abc", value)
+
     @skipIf(sys.version_info < (3, 7), "@dataclass needs at least Python 3.7")
     def test_dataclass_decorator(self):
         exec(textwrap.dedent("""


### PR DESCRIPTION
For convenience reasons one may pass an empty (e.g. test) context of value None instead of {}